### PR TITLE
Fix conflicting names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
-    "bin": "bin/install.js",
+    "bin": {
+        "bin/install.js": "try-deno"
+    },
     "dependencies": {
         "dafo": "^0.1.0",
         "qir": "0.0.2"


### PR DESCRIPTION
The executable name of this package may conflict with Deno's official package when they release it via NPM, as discussed in https://github.com/denoland/deno_install/issues/6

Would you consider changing this?